### PR TITLE
Update solution, remove project, and enhance Policy UI

### DIFF
--- a/IntuneAssignments.sln
+++ b/IntuneAssignments.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntuneAssignments", "Intune
 EndProject
 Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "Intune Assignment Installer", "..\Intune Assignment Installer\Intune Assignment Installer.vdproj", "{BA926106-6270-4CDA-8C74-9F624B5B4041}"
 EndProject
-Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "Intune Assignment Installer", "..\Intune Assignment Installer\Intune Assignment Installer.vdproj", "{3382EFFB-74D1-4C9D-BE49-0826203DCFA2}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,8 +19,6 @@ Global
 		{2416D879-25B6-4DDD-89FE-DAA40B0963C0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BA926106-6270-4CDA-8C74-9F624B5B4041}.Debug|Any CPU.ActiveCfg = Debug
 		{BA926106-6270-4CDA-8C74-9F624B5B4041}.Release|Any CPU.ActiveCfg = Release
-		{3382EFFB-74D1-4C9D-BE49-0826203DCFA2}.Debug|Any CPU.ActiveCfg = Debug
-		{3382EFFB-74D1-4C9D-BE49-0826203DCFA2}.Release|Any CPU.ActiveCfg = Release
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Presentation/Policy/Policy.Designer.cs
+++ b/Presentation/Policy/Policy.Designer.cs
@@ -54,6 +54,7 @@
             groupType = new DataGridViewTextBoxColumn();
             dataGridViewTextBoxColumn2 = new DataGridViewTextBoxColumn();
             cmsDisplayGroup = new ContextMenuStrip(components);
+            copyCellContentToolStripMenuItem1 = new ToolStripMenuItem();
             btnListAllGroups = new Button();
             btnSearchGroup = new Button();
             txtboxSearchGroup = new TextBox();
@@ -83,7 +84,6 @@
             label1 = new Label();
             pbViewAssignments = new PictureBox();
             lblHeaderAppForm = new Label();
-            copyCellContentToolStripMenuItem1 = new ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)pbHome).BeginInit();
             pnlSearchPolicy.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)dtgDisplayPolicy).BeginInit();
@@ -347,7 +347,14 @@
             // 
             cmsDisplayGroup.Items.AddRange(new ToolStripItem[] { copyCellContentToolStripMenuItem1 });
             cmsDisplayGroup.Name = "cmsDisplayGroup";
-            cmsDisplayGroup.Size = new Size(181, 48);
+            cmsDisplayGroup.Size = new Size(168, 26);
+            // 
+            // copyCellContentToolStripMenuItem1
+            // 
+            copyCellContentToolStripMenuItem1.Name = "copyCellContentToolStripMenuItem1";
+            copyCellContentToolStripMenuItem1.Size = new Size(167, 22);
+            copyCellContentToolStripMenuItem1.Text = "Copy cell content";
+            copyCellContentToolStripMenuItem1.Click += copyCellContentToolStripMenuItem1_Click;
             // 
             // btnListAllGroups
             // 
@@ -701,13 +708,6 @@
             lblHeaderAppForm.Size = new Size(207, 28);
             lblHeaderAppForm.TabIndex = 21;
             lblHeaderAppForm.Text = "Deploy policies";
-            // 
-            // copyCellContentToolStripMenuItem1
-            // 
-            copyCellContentToolStripMenuItem1.Name = "copyCellContentToolStripMenuItem1";
-            copyCellContentToolStripMenuItem1.Size = new Size(180, 22);
-            copyCellContentToolStripMenuItem1.Text = "Copy cell content";
-            copyCellContentToolStripMenuItem1.Click += copyCellContentToolStripMenuItem1_Click;
             // 
             // Policy
             // 

--- a/Presentation/Policy/Policy.cs
+++ b/Presentation/Policy/Policy.cs
@@ -1934,7 +1934,7 @@ namespace IntuneAssignments
             foreach (var profile in deviceConfigurationProfiles)
             {
 
-                dataGridView.Rows.Add(profile.DisplayName, "Device Configuration", profile.OdataType, profile.Id);
+                dataGridView.Rows.Add(profile.DisplayName, "Device Configuration", profile.OdataType.ToString(), profile.Id);
 
             }
 
@@ -1972,7 +1972,7 @@ namespace IntuneAssignments
             foreach (var policy in configurationPolicies)
             {
 
-                dataGridView.Rows.Add(policy.Name, "Settings Catalog", policy.Platforms, policy.Id);
+                dataGridView.Rows.Add(policy.Name, "Settings Catalog", policy.Platforms.ToString(), policy.Id);
 
             }
 

--- a/Presentation/Policy/Policy.resx
+++ b/Presentation/Policy/Policy.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter


### PR DESCRIPTION
Updated Visual Studio version in `IntuneAssignments.sln`. Removed `Intune Assignment Installer` project. Added `copyCellContentToolStripMenuItem1` to `cmsDisplayGroup` in `Policy.Designer.cs` and adjusted its size. Removed redundant declarations. Explicitly converted `OdataType` and `Platforms` to strings in `Policy.cs`. Made minor formatting changes in `Policy.resx`.